### PR TITLE
fix(hardware): Improve robustness of USB and network analyzers

### DIFF
--- a/tests/unit/hardware/test_network_analyzer.py
+++ b/tests/unit/hardware/test_network_analyzer.py
@@ -1053,7 +1053,7 @@ class TestNetworkPerformance:
             info = analyzer.analyze_network_performance()
             assert "performance_capabilities" in info
             assert "eth0" in info["performance_capabilities"]
-            assert info["performance_capabilities"]["eth0"]["speed"] == 1000
+            assert info["performance_capabilities"]["eth0"]["speed"] == MOCK_SYS_SPEED
             assert (
                 info["performance_capabilities"]["eth0"]["duplex"]
                 == psutil.NIC_DUPLEX_FULL
@@ -1066,13 +1066,15 @@ class TestNetworkPerformance:
             CommandResult(False, "", "not found", 1),
         ]
         psutil_error = Exception("psutil error")
-        with patch("psutil.net_if_stats", side_effect=psutil_error):
-            with patch.object(analyzer, "logger") as mock_logger:
-                info = analyzer.analyze_network_performance()
-                assert "performance_capabilities" not in info
-                mock_logger.error.assert_called_with(
-                    "Failed to get psutil stats for %s: %s", "eth0", psutil_error
-                )
+        with (
+            patch("psutil.net_if_stats", side_effect=psutil_error),
+            patch.object(analyzer, "logger") as mock_logger,
+        ):
+            info = analyzer.analyze_network_performance()
+            assert "performance_capabilities" not in info
+            mock_logger.error.assert_called_with(
+                "Failed to get psutil stats for %s: %s", "eth0", psutil_error
+            )
 
     def test_parse_ethtool_capabilities(self, analyzer):
         """Test parsing of `ethtool` capabilities output."""

--- a/tests/unit/hardware/test_usb_analyzer.py
+++ b/tests/unit/hardware/test_usb_analyzer.py
@@ -284,7 +284,9 @@ class TestUSBAnalyzer(unittest.TestCase):
             CommandResult(
                 success=True,
                 # lsusb output with different bus/device numbers
-                stdout="Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub\n",
+                stdout=(
+                    "Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub\n"
+                ),
                 stderr="",
                 returncode=0,
             ),
@@ -383,3 +385,47 @@ class TestUSBAnalyzer(unittest.TestCase):
         self.assertEqual(len(root_hubs), 1)
         # Root hub should have no children since orphaned device was skipped
         self.assertEqual(len(root_hubs[0]["children"]), 0)
+
+    def test_sysfs_empty_busnum_devnum(self):
+        """Test that devices with empty busnum or devnum are skipped."""
+        mock_system_interface = Mock()
+        mock_system_interface.run_command.side_effect = [
+            CommandResult(
+                success=True,
+                stdout=MOCK_LSUSB_T_OUTPUT,
+                stderr="",
+                returncode=0,
+            ),
+            CommandResult(
+                success=True,
+                stdout=MOCK_LSUSB_OUTPUT,
+                stderr="",
+                returncode=0,
+            ),
+        ]
+        # Mock list_dir to return directories
+        mock_system_interface.list_dir.return_value = ["2-1", "2-2", "2-3"]
+
+        # Mock read_file to return empty strings for specific paths
+        def mock_read_file(path):
+            if path == "/sys/bus/usb/devices/2-1/busnum":
+                return ""  # Empty busnum
+            elif path == "/sys/bus/usb/devices/2-1/devnum":
+                return "1"
+            elif path == "/sys/bus/usb/devices/2-2/busnum":
+                return "2"
+            elif path == "/sys/bus/usb/devices/2-2/devnum":
+                return None  # None devnum
+            elif path in MOCK_SYSFS_DATA:
+                return MOCK_SYSFS_DATA[path]
+            raise FileNotFoundError(f"File not found: {path}")
+
+        mock_system_interface.read_file = Mock(side_effect=mock_read_file)
+
+        analyzer = USBAnalyzer(system_interface=mock_system_interface)
+        usb_info = analyzer.get_usb_info()
+
+        # Verify that lsusb was called as fallback
+        self.assertEqual(mock_system_interface.run_command.call_count, 2)
+        root_hubs = usb_info.tree.get("root_hubs", [])
+        self.assertEqual(len(root_hubs), 2)

--- a/tinel/hardware/network_analyzer.py
+++ b/tinel/hardware/network_analyzer.py
@@ -673,8 +673,8 @@ class NetworkAnalyzer:
             A dictionary of the parsed capabilities.
         """
         capabilities: Dict[str, Any] = {}
-        for line in ethtool_output.strip().split("\n"):
-            line = line.strip()
+        for line_raw in ethtool_output.strip().split("\n"):
+            line = line_raw.strip()
             if ":" in line:
                 key, value = line.split(":", 1)
                 key = key.strip().lower().replace(" ", "_")

--- a/tinel/hardware/usb_analyzer.py
+++ b/tinel/hardware/usb_analyzer.py
@@ -99,25 +99,36 @@ class USBAnalyzer:
                     busnum_path = f"{dev_path}/busnum"
                     devnum_path = f"{dev_path}/devnum"
 
-                    bus_num_content = self.system.read_file(busnum_path).strip()
-                    dev_num_content = self.system.read_file(devnum_path).strip()
+                    bus_num_content_raw = self.system.read_file(busnum_path)
+                    dev_num_content_raw = self.system.read_file(devnum_path)
+
+                    if not bus_num_content_raw or not dev_num_content_raw:
+                        continue
+
+                    bus_num_content = bus_num_content_raw.strip()
+                    dev_num_content = dev_num_content_raw.strip()
 
                     if int(bus_num_content) == int(bus) and int(dev_num_content) == int(
                         dev_id
                     ):
+                        vendor_id_raw = self.system.read_file(f"{dev_path}/idVendor")
+                        product_id_raw = self.system.read_file(f"{dev_path}/idProduct")
+                        manufacturer_raw = self.system.read_file(
+                            f"{dev_path}/manufacturer"
+                        )
+                        product_raw = self.system.read_file(f"{dev_path}/product")
+
                         details: Dict[str, Any] = {
-                            "vendor_id": self.system.read_file(
-                                f"{dev_path}/idVendor"
-                            ).strip(),
-                            "product_id": self.system.read_file(
-                                f"{dev_path}/idProduct"
-                            ).strip(),
-                            "manufacturer": self.system.read_file(
-                                f"{dev_path}/manufacturer"
-                            ).strip(),
-                            "product": self.system.read_file(
-                                f"{dev_path}/product"
-                            ).strip(),
+                            "vendor_id": vendor_id_raw.strip()
+                            if vendor_id_raw
+                            else None,
+                            "product_id": product_id_raw.strip()
+                            if product_id_raw
+                            else None,
+                            "manufacturer": manufacturer_raw.strip()
+                            if manufacturer_raw
+                            else None,
+                            "product": product_raw.strip() if product_raw else None,
                         }
                         return details
                 except (IOError, OSError, FileNotFoundError):
@@ -133,7 +144,7 @@ class USBAnalyzer:
         This method caches the output of the `lsusb` command to avoid
         running it multiple times during a single analysis.
         """
-        details = {}
+        details: Dict[str, str] = {}
         if self._lsusb_output_cache is None:
             self._lsusb_output_cache = self.system.run_command(["lsusb"])
 
@@ -141,7 +152,6 @@ class USBAnalyzer:
         if not lsusb_output.success:
             return details
 
-        # Example: "Bus 002 Device 002: ID 0bda:579c Realtek Semiconductor Corp. Webcam"
         pattern = re.compile(
             r"Bus\s+{0:03d}\s+Device\s+{1:03d}:\s+ID\s+([0-9a-fA-F]{{4}}):([0-9a-fA-F]{{4}})".format(
                 int(bus), int(dev_id)


### PR DESCRIPTION
This commit enhances the hardware analyzers to be more resilient to missing or incomplete data, particularly from the sysfs filesystem.

 The key changes include:
 - The `USBAnalyzer` now gracefully handles cases where `busnum`, `devnum`, or other device attribute files in `/sys/bus/usb/devices` are empty or unreadable. This prevents potential crashes and ensures that the analysis can continue even with malformed sysfs data.
 - A new unit test has been added to verify that the `USBAnalyzer` correctly skips devices with empty `busnum` or `devnum` files.
 - In the `NetworkAnalyzer`, a magic number for network speed has been replaced with a constant in the tests for better readability and maintainability.
 - Minor code style and formatting improvements have been applied to both the analyzers and their corresponding tests.